### PR TITLE
Stop using SuPeRfail

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -86,7 +86,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.7",
+  GAP := ">=4.8.2",
   NeededOtherPackages := [ ["GAPDoc", ">= 1.3"], 
                            ["openmath", ">= 11.0.0"],
                            ["IO", ">= 3.0"] ],

--- a/demo/rundemo.g
+++ b/demo/rundemo.g
@@ -28,13 +28,13 @@ BindGlobal( "Demonstration", function( file )
     Print( "\033[34m", "demo> \c", "\033[0m" );
     while CHAR_INT( ReadByte( keyboard ) ) <> 'q' do
         storedtime := Runtime();
-        result:=READ_COMMAND( input, true ); # Executing the command.
+        result:=READ_COMMAND_REAL( input, true ); # Executing the command.
         time := Runtime()-storedtime;
-        if result <> SuPeRfail then
+        if Length(result) = 2 then
             last3 := last2;
             last2 := last;
-            last := result;
-            View(result);
+            last := result[2];
+            View(result[2]);
             Print("\n" );
         fi;
 


### PR DESCRIPTION
Reimplement demo mode using READ_COMMAND_REAL, available
in GAP 4.8.2 and later.

See https://github.com/gap-system/gap/issues/560