### PR TITLE
Refactor OMgetObjectXMLTreeWithAttributes (First step)

### DIFF
--- a/lib/openmath.g
+++ b/lib/openmath.g
@@ -337,18 +337,18 @@ end );
 ## This is a counterpart of the OpenMath function OMgetObjectXMLTree
 ##
 InstallGlobalFunction( OMgetObjectXMLTreeWithAttributes,
-    function ( string )
+function(string)
     local return_tree, return_deferred, node, attrs, t, obj, pos, name;
-    
+
     if ValueOption("return_tree") <> fail then
         return_tree := true;
     else
-        return_tree := false;  
+        return_tree := false;
     fi;
 
     OMTempVars.OMBIND := rec(  );
     OMTempVars.OMREF := rec(  );
-    
+
     # This is the difference from OMgetObjectXMLTree
     OMTempVars.OMATTR := rec(  );
 
@@ -357,91 +357,90 @@ InstallGlobalFunction( OMgetObjectXMLTreeWithAttributes,
     node.content := Filtered( node.content, OMIsNotDummyLeaf );
 
     # Print( "ParseTreeXMLString( string ) = ", node.content, "\n" );
-    
+
     attrs := List( Filtered( node.content[1].content, t -> t.name = "OMATP" ), OMParseXmlObj );
-    
+
     if Length(attrs)=1 then
-      attrs:=attrs[1];
+        attrs:=attrs[1];
     fi;
-       
+
     # At this point we already know attributes BEFORE the the real computation is started.
     # This allows us to know in advance which kind of return (object/cookie/tree)
     # is expected, and which runtime and memory limits were specified, if any.
 
-	# Now we will check that this is really procedure_call message and that
-	# the procedure is allowed, that is, it is from scscp{1,2} or scscp_transient_X CD
-	
-	if SCSCPserverMode then
-	
-	    SCSCP_UNBIND_MODE := false;
+    # Now we will check that this is really procedure_call message and that
+    # the procedure is allowed, that is, it is from scscp{1,2} or scscp_transient_X CD
+
+    if SCSCPserverMode then
+
+        SCSCP_UNBIND_MODE := false;
         SCSCP_STORE_SESSION_MODE := true;
-    
-    	pos:=PositionProperty( node.content[1].content, r -> r.name="OMA");	# expected scscp1.procedure_call
-    	if pos=fail then
-			return rec( object := [ "Message rejected: it must be a proper scscp1.procedure_call" ],
-			            attributes := attrs, is_error:=true );
-		else
-			node.content[1].content[pos].content := 
-				Filtered( node.content[1].content[pos].content, OMIsNotDummyLeaf );
-			if not IsBound( node.content[1].content[pos].content[1] ) or 
-			   not IsBound( node.content[1].content[pos].content[1].attributes ) or
-			   not node.content[1].content[pos].content[1].attributes in 
-			   [ rec( name := "procedure_call", cd := "scscp1" ),
-			     rec( name := "procedure_completed", cd := "scscp1" ),
-			     rec( name := "procedure_terminated", cd := "scscp1") ] 
-			   then
-				return rec( object := [ "Message rejected because it is not a proper scscp1.procedure_call" ],
-			                attributes := attrs, is_error:=true );				
-    		else
-    			node.content[1].content[pos].content[2].content := 
-    				Filtered( node.content[1].content[pos].content[2].content, OMIsNotDummyLeaf );
-    			if not IsBound( node.content[1].content[pos].content[2].content[1] ) or
-    			   not IsBound( node.content[1].content[pos].content[2].content[1].attributes ) or
-    			   not IsBound( node.content[1].content[pos].content[2].content[1].attributes.cd ) then
-				return rec( object := [ "Message rejected because it is not properly formatted" ],
-			                attributes := attrs, is_error:=true );		    			   
-    			elif SCSCPserverAcceptsOnlyTransientCD and 
-    			  ( Length( node.content[1].content[pos].content[2].content[1].attributes.cd ) < 5 or 
-    			  not node.content[1].content[pos].content[2].content[1].attributes.cd{[1..5]} = "scscp" ) then
-					return rec( object := [
-    					"Message rejected because the procedure ",
-    					node.content[1].content[pos].content[2].content[1].attributes.cd, ".",
-    					node.content[1].content[pos].content[2].content[1].attributes.name, 
-    					" is not allowed"], 
-			            attributes := attrs, is_error:=true );
-			    else
-			    	# some checks for some particular special procedures might be here
-			    	if node.content[1].content[pos].content[2].content[1].attributes.cd = "scscp2" then
-			    	    name := node.content[1].content[pos].content[2].content[1].attributes.name;
-			    	    if name = "unbind" then
-			    	        SCSCP_UNBIND_MODE := true; 
-			    	    elif name = "store_persistent" then
-                            SCSCP_STORE_SESSION_MODE := false;		    	        
-			    	    fi;
-			    	fi; 
-    			fi;
-			fi;
-		fi;
-	
-	fi;
-	
-	# if the security check is done, we may proceed
-	
-	if ForAny( attrs, t -> t[1]="option_return_deferred" ) then
-		return_deferred := true;
-	else
-		return_deferred := false;	
-	fi;
-	
+
+        pos:=PositionProperty( node.content[1].content, r -> r.name="OMA");	# expected scscp1.procedure_call
+        if pos=fail then
+            return rec( object := [ "Message rejected: it must be a proper scscp1.procedure_call" ],
+                        attributes := attrs, is_error:=true );
+        else
+            node.content[1].content[pos].content :=
+              Filtered( node.content[1].content[pos].content, OMIsNotDummyLeaf );
+            if not IsBound( node.content[1].content[pos].content[1] ) or
+               not IsBound( node.content[1].content[pos].content[1].attributes ) or
+               not node.content[1].content[pos].content[1].attributes in
+               [ rec( name := "procedure_call", cd := "scscp1" ),
+                 rec( name := "procedure_completed", cd := "scscp1" ),
+                 rec( name := "procedure_terminated", cd := "scscp1") ]
+              then
+                return rec( object := [ "Message rejected because it is not a proper scscp1.procedure_call" ],
+                            attributes := attrs, is_error:=true );
+            else
+                node.content[1].content[pos].content[2].content :=
+                  Filtered( node.content[1].content[pos].content[2].content, OMIsNotDummyLeaf );
+                if not IsBound( node.content[1].content[pos].content[2].content[1] ) or
+                   not IsBound( node.content[1].content[pos].content[2].content[1].attributes ) or
+                   not IsBound( node.content[1].content[pos].content[2].content[1].attributes.cd ) then
+                    return rec( object := [ "Message rejected because it is not properly formatted" ],
+                                attributes := attrs, is_error:=true );
+                elif SCSCPserverAcceptsOnlyTransientCD and
+                  ( Length( node.content[1].content[pos].content[2].content[1].attributes.cd ) < 5 or
+                    not node.content[1].content[pos].content[2].content[1].attributes.cd{[1..5]} = "scscp" ) then
+                    return rec( object := [
+                                   "Message rejected because the procedure ",
+                                   node.content[1].content[pos].content[2].content[1].attributes.cd, ".",
+                                   node.content[1].content[pos].content[2].content[1].attributes.name,
+                                   " is not allowed"],
+                                attributes := attrs, is_error:=true );
+                else
+                    # some checks for some particular special procedures might be here
+                    if node.content[1].content[pos].content[2].content[1].attributes.cd = "scscp2" then
+                        name := node.content[1].content[pos].content[2].content[1].attributes.name;
+                        if name = "unbind" then
+                            SCSCP_UNBIND_MODE := true;
+                        elif name = "store_persistent" then
+                            SCSCP_STORE_SESSION_MODE := false;
+                        fi;
+                    fi;
+                fi;
+            fi;
+        fi;
+
+    fi;
+
+    # if the security check is done, we may proceed
+    if ForAny( attrs, t -> t[1]="option_return_deferred" ) then
+        return_deferred := true;
+    else
+        return_deferred := false;
+    fi;
+
     if return_tree or return_deferred then
         obj := node.content[1];
     else
         obj := OMParseXmlObj( node.content[1] );
     fi;
-    
+
     # the next check was is a temporary measure to verify that
     # attributes were identified properly
-    
+
     #if OMTempVars.OMATTR <> rec() then
     #  if OMParseXmlObj( OMTempVars.OMATTR ) <> attrs then
     #    Error("Attributes were not properly identified:\n",
@@ -451,7 +450,6 @@ InstallGlobalFunction( OMgetObjectXMLTreeWithAttributes,
     #fi;
 
     return rec( object:=obj, attributes:=attrs );
-
 end );
 
 

--- a/lib/openmath.g
+++ b/lib/openmath.g
@@ -329,6 +329,56 @@ function( stream )
     fi;
 end );
 
+# FIXME: This should be done on creation of the tree
+InstallGlobalFunction(FilterContent,
+function(node)
+    node.content := Filtered(node.content, OMIsNotDummyLeaf);
+    return node;
+end);
+
+# FIXME: Does the SCSCP specification actually guarantee the order
+#        of content?
+#        Do we need to enable more fine-grained error messages?
+#        Maybe we can make this more transparent
+#
+#! @Description
+#!   Extracts an SCSCP procedure call from a record XML-Tree
+#!   representation and returns a record containing the cd and
+#!   the name of the procedure that is to be called.
+#!   If the record does not contain a valid SCSCP call, then
+#!   this function returns fail.
+InstallGlobalFunction(SCSCP_GetProcedureCall,
+function(node)
+    local pos, apply;
+
+	  # expecting scscp1.procedure_call
+    pos := PositionProperty( node.content, r -> r.name="OMA");
+    if pos <> fail then
+        apply := node.content[pos];
+        FilterContent(apply);
+        FilterContent(apply.content[2]);
+        if IsBound( apply.content[1] ) and
+           IsBound( apply.content[1].attributes ) and
+           (apply.content[1].attributes in
+            [ rec( name := "procedure_call", cd := "scscp1" ),
+              rec( name := "procedure_completed", cd := "scscp1" ),
+              rec( name := "procedure_terminated", cd := "scscp1") ] ) and
+           IsBound( apply.content[2].content[1] ) and
+           IsBound( apply.content[2].content[1].attributes ) and
+           IsBound( apply.content[2].content[1].attributes.cd ) and
+           IsBound( apply.content[2].content[1].attributes.name ) then
+            return rec( cd := apply.content[2].content[1].attributes.cd
+                      , name := apply.content[2].content[1].attributes.name );
+        fi;
+    fi;
+    return fail;
+end);
+
+InstallGlobalFunction(SCSCP_IsTransientProcedureCall,
+                      apply -> Length( apply.cd ) >= 5 and apply.cd{[1..5]} = "scscp");
+
+InstallGlobalFunction(SCSCP_IsDeferredProcedureCall,
+                      attrs -> ForAny( attrs, t -> t[1] = "option_return_deferred"));
 
 #############################################################################
 ##
@@ -338,7 +388,7 @@ end );
 ##
 InstallGlobalFunction( OMgetObjectXMLTreeWithAttributes,
 function(string)
-    local return_tree, return_deferred, node, attrs, t, obj, pos, name;
+    local return_tree, apply, node, attrs, obj, cd, name;
 
     if ValueOption("return_tree") <> fail then
         return_tree := true;
@@ -354,14 +404,13 @@ function(string)
 
     node := ParseTreeXMLString( string ).content[1];
 
-    node.content := Filtered( node.content, OMIsNotDummyLeaf );
-
-    # Print( "ParseTreeXMLString( string ) = ", node.content, "\n" );
+    FilterContent(node);
 
     attrs := List( Filtered( node.content[1].content, t -> t.name = "OMATP" ), OMParseXmlObj );
 
-    if Length(attrs)=1 then
-        attrs:=attrs[1];
+    # TODO: Justify this
+    if Length(attrs) = 1 then
+        attrs := attrs[1];
     fi;
 
     # At this point we already know attributes BEFORE the the real computation is started.
@@ -370,86 +419,44 @@ function(string)
 
     # Now we will check that this is really procedure_call message and that
     # the procedure is allowed, that is, it is from scscp{1,2} or scscp_transient_X CD
-
     if SCSCPserverMode then
-
+        # TODO: This is global state, what does it do
+        #       and can we make it non-global?
         SCSCP_UNBIND_MODE := false;
         SCSCP_STORE_SESSION_MODE := true;
 
-        pos:=PositionProperty( node.content[1].content, r -> r.name="OMA");	# expected scscp1.procedure_call
-        if pos=fail then
-            return rec( object := [ "Message rejected: it must be a proper scscp1.procedure_call" ],
-                        attributes := attrs, is_error:=true );
-        else
-            node.content[1].content[pos].content :=
-              Filtered( node.content[1].content[pos].content, OMIsNotDummyLeaf );
-            if not IsBound( node.content[1].content[pos].content[1] ) or
-               not IsBound( node.content[1].content[pos].content[1].attributes ) or
-               not node.content[1].content[pos].content[1].attributes in
-               [ rec( name := "procedure_call", cd := "scscp1" ),
-                 rec( name := "procedure_completed", cd := "scscp1" ),
-                 rec( name := "procedure_terminated", cd := "scscp1") ]
-              then
-                return rec( object := [ "Message rejected because it is not a proper scscp1.procedure_call" ],
-                            attributes := attrs, is_error:=true );
-            else
-                node.content[1].content[pos].content[2].content :=
-                  Filtered( node.content[1].content[pos].content[2].content, OMIsNotDummyLeaf );
-                if not IsBound( node.content[1].content[pos].content[2].content[1] ) or
-                   not IsBound( node.content[1].content[pos].content[2].content[1].attributes ) or
-                   not IsBound( node.content[1].content[pos].content[2].content[1].attributes.cd ) then
-                    return rec( object := [ "Message rejected because it is not properly formatted" ],
-                                attributes := attrs, is_error:=true );
-                elif SCSCPserverAcceptsOnlyTransientCD and
-                  ( Length( node.content[1].content[pos].content[2].content[1].attributes.cd ) < 5 or
-                    not node.content[1].content[pos].content[2].content[1].attributes.cd{[1..5]} = "scscp" ) then
-                    return rec( object := [
-                                   "Message rejected because the procedure ",
-                                   node.content[1].content[pos].content[2].content[1].attributes.cd, ".",
-                                   node.content[1].content[pos].content[2].content[1].attributes.name,
-                                   " is not allowed"],
-                                attributes := attrs, is_error:=true );
-                else
-                    # some checks for some particular special procedures might be here
-                    if node.content[1].content[pos].content[2].content[1].attributes.cd = "scscp2" then
-                        name := node.content[1].content[pos].content[2].content[1].attributes.name;
-                        if name = "unbind" then
-                            SCSCP_UNBIND_MODE := true;
-                        elif name = "store_persistent" then
-                            SCSCP_STORE_SESSION_MODE := false;
-                        fi;
-                    fi;
-                fi;
-            fi;
+        apply := SCSCP_GetProcedureCall(node.content[1].content);
+        if apply = fail then
+            return rec( object := [ "Message rejected: expected scscp1.procedure_call" ],
+                        attributes := attrs, is_error := true );
         fi;
 
+        if SCSCPserverAcceptsOnlyTransientCD and
+           not SCSCP_IsTransientProcedureCall(apply) then
+            return rec( object := [ "Message rejected: no permission to execute ",
+                                    apply.cd, ".", apply.name, "."],
+                        attributes := attrs, is_error := true );
+        fi;
+
+        # some checks for some particular special procedures might be here
+        # FIXME: This should really have a handler?
+        if apply.cd = "scscp2" then
+            if apply.name = "unbind" then
+                SCSCP_UNBIND_MODE := true;
+            elif apply.name = "store_persistent" then
+                SCSCP_STORE_SESSION_MODE := false;
+            fi;
+        fi;
     fi;
 
-    # if the security check is done, we may proceed
-    if ForAny( attrs, t -> t[1]="option_return_deferred" ) then
-        return_deferred := true;
-    else
-        return_deferred := false;
-    fi;
-
-    if return_tree or return_deferred then
+    if return_tree or SCSCP_IsDeferredProcedureCall(attrs) then
         obj := node.content[1];
     else
         obj := OMParseXmlObj( node.content[1] );
     fi;
 
-    # the next check was is a temporary measure to verify that
-    # attributes were identified properly
-
-    #if OMTempVars.OMATTR <> rec() then
-    #  if OMParseXmlObj( OMTempVars.OMATTR ) <> attrs then
-    #    Error("Attributes were not properly identified:\n",
-    #    "OMParseXmlObj( OMTempVars.OMATTR ) = ", OMParseXmlObj( OMTempVars.OMATTR ), "\n",
-    #    "attrs = ", attrs );
-    #  fi;
-    #fi;
-
-    return rec( object:=obj, attributes:=attrs );
+    return rec( object := obj
+              , attributes := attrs );
 end );
 
 

--- a/lib/openmath.gd
+++ b/lib/openmath.gd
@@ -81,6 +81,12 @@
 ##
 DeclareGlobalFunction( "OMGetObjectWithAttributes" );
 
+
+DeclareGlobalFunction( "FilterContent" );
+DeclareGlobalFunction( "SCSCP_GetProcedureCall");
+DeclareGlobalFunction( "SCSCP_IsTransientProcedureCall");
+DeclareGlobalFunction( "SCSCP_IsDeferredProcedureCall");
+
 DeclareGlobalFunction( "OMgetObjectXMLTreeWithAttributes" );
 
 

--- a/tst/xmltree.tst
+++ b/tst/xmltree.tst
@@ -1,0 +1,47 @@
+#
+gap> t:="";; stream:=OutputTextString(t,true);;
+gap> OMPutProcedureCall( stream, "WS_Factorial", rec( object:= [ 5 ], 
+>      attributes:=[ [ "call_id", "user007" ], 
+>                    ["option_runtime",1000],
+>                    ["option_min_memory",1024], 
+>                    ["option_max_memory",2048],
+>                    ["option_debuglevel",1], 
+>                    ["option_return_object"] ] ) );;
+gap> Print(t);
+<?scscp start ?>
+<OMOBJ xmlns="http://www.openmath.org/OpenMath" version="2.0">
+	<OMATTR>
+		<OMATP>
+			<OMS cd="scscp1" name="call_id"/>
+			<OMSTR>user007</OMSTR>
+			<OMS cd="scscp1" name="option_runtime"/>
+			<OMI>1000</OMI>
+			<OMS cd="scscp1" name="option_min_memory"/>
+			<OMI>1024</OMI>
+			<OMS cd="scscp1" name="option_max_memory"/>
+			<OMI>2048</OMI>
+			<OMS cd="scscp1" name="option_debuglevel"/>
+			<OMI>1</OMI>
+			<OMS cd="scscp1" name="option_return_object"/>
+			<OMSTR></OMSTR>
+		</OMATP>
+		<OMA>
+			<OMS cd="scscp1" name="procedure_call"/>
+			<OMA>
+				<OMS cd="scscp_transient_1" name="WS_Factorial"/>
+				<OMI>5</OMI>
+			</OMA>
+		</OMA>
+	</OMATTR>
+</OMOBJ>
+<?scscp end ?>
+
+#
+gap> tt := ParseTreeXMLString(t);;
+gap> SCSCP_GetProcedureCall(tt);
+fail
+gap> node := tt.content[3];; FilterContent(node);; node := node.content[1];;
+gap> SCSCP_GetProcedureCall(node);
+rec( cd := "scscp_transient_1", name := "WS_Factorial" )
+
+#


### PR DESCRIPTION
This is a first step towards moving all OpenMath object handling to the
OpenMath package. Refactoring these functions will make it easier to justify
code movements later. It also makes the code easier to understand and debug.