### PR TITLE
Add scscp08.tst to the test

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -9,12 +9,12 @@ SetPackageInfo( rec(
 
 PackageName := "SCSCP",
 Subtitle := "Symbolic Computation Software Composability Protocol in GAP",
-Version := "2.2.3",
-Date := "24/09/2017",
+Version := "2.2.4",
+Date := "22/12/2018",
 ##  <#GAPDoc Label="PKGVERSIONDATA">
-##  <!ENTITY VERSION "2.2.3">
-##  <!ENTITY RELEASEDATE "24 September 2017">
-##  <!ENTITY RELEASEYEAR "2017">
+##  <!ENTITY VERSION "2.2.4">
+##  <!ENTITY RELEASEDATE "22 December 2018">
+##  <!ENTITY RELEASEYEAR "2018">
 ##  <#/GAPDoc>
 
 SourceRepository := rec(

--- a/gapd.sh
+++ b/gapd.sh
@@ -48,7 +48,7 @@
 ##  example, memory usage, start with the workspace etc. The path may be 
 ##  relative (to start from this directory) or absolute. 
 ##
-GAP="$GAPROOT/bin/gap.sh -b -r $GAPOPTS"
+GAP="$GAPROOT/bin/gap.sh -b $GAPOPTS"
 ##
 ###########################################################################
 ##

--- a/lib/openmath.gd
+++ b/lib/openmath.gd
@@ -81,12 +81,6 @@
 ##
 DeclareGlobalFunction( "OMGetObjectWithAttributes" );
 
-
-DeclareGlobalFunction( "FilterContent" );
-DeclareGlobalFunction( "SCSCP_GetProcedureCall");
-DeclareGlobalFunction( "SCSCP_IsTransientProcedureCall");
-DeclareGlobalFunction( "SCSCP_IsDeferredProcedureCall");
-
 DeclareGlobalFunction( "OMgetObjectXMLTreeWithAttributes" );
 
 

--- a/lib/process.gi
+++ b/lib/process.gi
@@ -248,10 +248,7 @@ end);
 # TerminateProcess( <process> )
 #
 InstallGlobalFunction( TerminateProcess, function( process )
-# THIS WORKS ONLY LOCALLY
-if process![1]![2]="localhost" then
-  IO_kill( process![2], IO.SIGINT );
-fi;  
+CloseStream(process![1]);
 end);
 
 
@@ -399,8 +396,7 @@ while Length(waitinglist) > 0 do
   if result[nrprocess].object = true then
     Info( InfoSCSCP, 1, "Process number ", nrprocess, " returned true, closing remaining processes");
     for i in waitinglist do
-      # TerminateProcess( processes[i] );
-      CloseStream( processes[i]![1]);
+      TerminateProcess( processes[i] );
     od;
     return result;
   fi;    
@@ -436,8 +432,7 @@ elif descriptors[2]<>fail then # 2nd process is ready
   result[2] := CompleteProcess( b );
   if result[2].object = true then
     Info( InfoSCSCP, 1, "Process number 2 returned true, closing process number 1");
-    CloseStream( a![1] );
-    # TerminateProcess( a );
+    TerminateProcess( a );
     return result;
   fi;  
   Info( InfoSCSCP, 1, "Closed 2nd process, waiting for 1st ...");  

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -15,14 +15,11 @@ if PingSCSCPservice( "localhost", 26134 ) = fail then
   FORCE_QUIT_GAP(1);
 fi;
 
-# TODO: "scscp08.tst" requires also the 2nd server at port 26134
-# Currently the test hangs, and its testing is suppressed.
-
 # Run tests which include technical details like random call
 # identifiers and need manual inspection
 TestDirectory(DirectoriesPackageLibrary( "scscp", "tst" ),
   rec(exitGAP     := false,
-      exclude     := [ "scscp08.tst", "scscp.tst", "offline.tst" ],
+      exclude     := [ "scscp.tst", "offline.tst", "xmltree.tst" ],
       testOptions := rec(compareFunction := "uptowhitespace") ) );
 
 # Run test files which should have no diffs

--- a/tst/xmltree.tst
+++ b/tst/xmltree.tst
@@ -37,11 +37,13 @@ gap> Print(t);
 <?scscp end ?>
 
 #
+gap> InstallSCSCPprocedure("WS_Factorial",Factorial : force);
 gap> tt := ParseTreeXMLString(t);;
-gap> SCSCP_GetProcedureCall(tt);
-fail
-gap> node := tt.content[3];; FilterContent(node);; node := node.content[1];;
-gap> SCSCP_GetProcedureCall(node);
-rec( cd := "scscp_transient_1", name := "WS_Factorial" )
-
-#
+gap> node := tt.content[3];;
+gap> node.content := Filtered( node.content, OMIsNotDummyLeaf );;
+gap> attrs := List( Filtered( node.content[1].content, t -> t.name = "OMATP" ), OMParseXmlObj );
+[ [ [ "call_id", "user007" ], [ "option_runtime", 1000 ], 
+      [ "option_min_memory", 1024 ], [ "option_max_memory", 2048 ], 
+      [ "option_debuglevel", 1 ], [ "option_return_object", "" ] ] ]
+gap> OMParseXmlObj( node.content[1] );
+120


### PR DESCRIPTION
This reverts part of #16 which was not tested well enough before merging, and will thus close #21. Code reformatting from #16 stays, and new test file `xmltree.tst` is adjusted accordingly.

This PR also fixes testing setup, and increments version to ensure that we can see that SCSCP serves also run the new version of the package instead of the one picked up from the GAP redistribution (was happening before since the server uses `-r` option to start GAP). It also adds one more test file, and fixes a problem in `TerminateProcess` to make it pass.