### PR TITLE
CI: Ensure code coverage reporting will work in February 2022 and beyond

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,4 +33,4 @@ jobs:
           GAPROOT="$HOME/gap" GAPOPTS="-l $PWD/gaproot;" ./gapd.sh -p 26134
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2


### PR DESCRIPTION
See https://github.com/gap-actions/process-coverage/issues/10
