### PR TITLE
Don't use bin/gap.sh

### DIFF
--- a/gapd.sh
+++ b/gapd.sh
@@ -48,7 +48,7 @@
 ##  example, memory usage, start with the workspace etc. The path may be 
 ##  relative (to start from this directory) or absolute. 
 ##
-GAP="$GAPROOT/bin/gap.sh -b $GAPOPTS"
+GAP="$GAPROOT/gap -b $GAPOPTS"
 ##
 ###########################################################################
 ##


### PR DESCRIPTION
GAP only provides it for backwards compatibility with old GAP versions.
Since GAP 4.9 one should instead just call the gap binary directly.
