### PR TITLE
Switch to two argument version of ReadPackage

### DIFF
--- a/doc/parallel.xml
+++ b/doc/parallel.xml
@@ -175,7 +175,7 @@ of degree 32000:
 
 <Example>
 <![CDATA[
-gap> ReadPackage("scscp/example/karatsuba.g");
+gap> ReadPackage("scscp", "example/karatsuba.g");
 true
 gap> fam:=FamilyObj(1);;
 gap> f:=LaurentPolynomialByCoefficients( fam, 

--- a/tst/scscp.tst
+++ b/tst/scscp.tst
@@ -9,7 +9,7 @@ gap> EvaluateBySCSCP( "WS_IdGroup", [ SymmetricGroup(3) ], server, 26133 ).objec
 [ 6, 1 ]
 gap> EvaluateBySCSCP( "GroupIdentificationService", [ [ (1,2,3), (2,3) ] ], server, 26133 ).object;
 [ 6, 1 ]
-gap> ReadPackage("scscp/example/id512.g");
+gap> ReadPackage("scscp", "example/id512.g");
 true
 gap> IdGroup512( DihedralGroup( 512 ) );
 [ 512, 2042 ]

--- a/tst/scscp08.tst
+++ b/tst/scscp08.tst
@@ -69,7 +69,7 @@ gap> ParListWithSCSCP( List( [2..6], n -> SymmetricGroup(n)), "WS_IdGroup" );
 [ [ 2, 1 ], [ 6, 1 ], [ 24, 12 ], [ 120, 34 ], [ 720, 763 ] ]
 
 # doc/parallel.xml:176-190
-gap> ReadPackage("scscp/example/karatsuba.g");
+gap> ReadPackage("scscp", "example/karatsuba.g");
 true
 gap> fam:=FamilyObj(1);;
 gap> f:=LaurentPolynomialByCoefficients( fam, 


### PR DESCRIPTION
The one argument form is not recommended, as it just has to split
the string into two anyway, and the input looks like a path, but
it isn't really, as the first part is a pacakge name, not a
directory name...
