### PR TITLE
Load SmallGrp explicitly in tst/offline.tst

### DIFF
--- a/tst/offline.tst
+++ b/tst/offline.tst
@@ -1,6 +1,8 @@
 gap> START_TEST( "offline.tst" );
 gap> LoadPackage("scscp");
 true
+gap> LoadPackage("smallgrp", false); # for the IdGroup/SmallGroup services below
+true
 gap> SetInfoLevel( InfoSCSCP, 0 );
 gap> t:="";; stream:=OutputTextString(t,true);;
 gap> OMPutProcedureCall( stream, "WS_Factorial", rec( object:= [ 5 ], 


### PR DESCRIPTION
The test installs IdGroup and SmallGroup as SCSCP procedures and then
replays an OpenMath file which invokes them, so it needs the SmallGrp
package; without it the test failed with

    Error, the Small Groups identification is required but not installed

Load it explicitly, as tst/testall.g already does.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
